### PR TITLE
Improve navigation on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,12 +31,12 @@ h2 {
 
 
 .header {
-  height: 80px;
   width: 100%;
   background-color: #eee;
   margin-left: 0px;
   padding: 0;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   position: sticky;
@@ -81,6 +81,10 @@ h2 {
   color: #B7A57A;
 }
 
+
+.header-cta-link {
+  margin-bottom: 15px;
+}
 
 .header-cta-link,
 .hero-cta-link,
@@ -264,6 +268,7 @@ a.anchor {
 @media (max-width: 600px) {
   .header {
     font-size: 16px;
+    position: static;
   }
 
   .header-logo {


### PR DESCRIPTION
Attempts to fix #7 

- Enabled wrapping for the header flexbox. On narrow screens, the elements just wrap.
- Made the header non-sticky for small devices using media queries. A large sticky wrapped header would just get in the way here.

I'm not sure if this solution is better or worse than the one @AlnisS proposes in issue #7. This pull request is just one possibility.

![better](https://github.com/UWCubeSat/hsl-website/assets/24969682/a0f68da4-4dfa-4a31-a7d8-ec2f14ad9dc1)
