### PR TITLE
Hacking in a hamburger menu

### DIFF
--- a/header.js
+++ b/header.js
@@ -7,6 +7,7 @@ document.write(
     <a class="header-link" href="https://newsletter.huskysat.org">NEWSLETTER</a>
     <a class="header-link" href="sponsors.html">SPONSORS</a>
     <a class="header-cta-link" href="join.html">JOIN US</a>
+    <button class="header-hamburger-button" onclick="document.querySelector('.header').classList.toggle('open')">\u2630</button>
 </div>
 `
 );

--- a/style.css
+++ b/style.css
@@ -92,6 +92,7 @@ h2 {
   color: #fff;
   text-decoration: none;
   transition-duration: 150ms;
+  transition-property: background-color;
   white-space: nowrap;
 }
 
@@ -260,21 +261,63 @@ a.anchor {
   visibility: hidden;
 }
 
+:nth-child(1) { --nth-child: 1 }
+:nth-child(2) { --nth-child: 2 }
+:nth-child(3) { --nth-child: 3 }
+:nth-child(4) { --nth-child: 4 }
+:nth-child(5) { --nth-child: 5 }
+:nth-child(6) { --nth-child: 6 }
 
 @media (max-width: 600px) {
-  .header {
-    font-size: 16px;
-  }
-
-  .header-logo {
-    background-size: 50px 50px;
-  }
-
   .header-link {
-    padding: 20px 5px;
+    margin: 20px 20px
   }
 
   .header-cta-link {
-    padding: 10px 10px;
+    margin: 40px 30px!important;
   }
+
+  .header.open {
+    height: 365px;
+  }
+
+  .header.open > .header-logo {
+    position: absolute;
+    left: 4px;
+    top: 4px;
+    width: 72px;
+    height: 72px;
+    margin: initial
+  }
+
+  .header > a:nth-child(n+2) {
+    position: absolute;
+    right: 0;
+    top: 0;
+    transform: translate(0px, calc(50px * (var(--nth-child) - 2) + 50px));
+  }
+
+  .header-hamburger-button {
+    display: block!important;
+  }
+
+  .header.open {
+    background: white;
+  }
+}
+
+.header {
+  overflow: hidden;
+}
+
+.header-hamburger-button {
+  height: 80px;
+  width: 80px;
+  font-size: 45px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: none;
+  border: none;
+  background: none
 }


### PR DESCRIPTION
Fixes #7 
Supersedes #24 

Uses CSS hacks to make the menu rearrange into a hamburger on small screens, and a button that toggles it opening.

There is a 95% chance of there being a better way to do this using flexbox instead of hacky CSS variable scripting, but it works!!