### PR TITLE
Center Apply Button

### DIFF
--- a/join.html
+++ b/join.html
@@ -52,7 +52,7 @@
       </p>
 
       <!-- TODO: improve CSS -->
-            <a class="header-cta-link" style="margin: 20px 0 10px 50%; transform: translate(-50%, 0); display: inline-block;"
+            <a class="cta-link" style="margin: 20px 0 10px 50%; transform: translate(-50%, 0); display: inline-block;"
         href="https://forms.gle/iJ6i6grWMquCwvjs6" target="_blank" rel="noopener noreferrer">APPLY NOW 🡒</a>
 
         <h3 class="join-subheading">Troubleshooting Info</h3>


### PR DESCRIPTION
fixes #27 

Turns out I accidentally set the button's class to "header-cta-link" which caused it to be moved when the header was resized. Changing its class to "cta-link" fixed this.