### PR TITLE
De-prioritize applications

### DIFF
--- a/join.html
+++ b/join.html
@@ -34,8 +34,11 @@
           href="https://drive.google.com/file/d/1IKCP3SmwRTipKP3ih5-Ac-5RBpQkQ2G9/view" target="_blank"
           rel="noopener noreferrer">flyer</a>.
         <br><br>
-        Our priority application deadline for 2023 has passed, but you can still apply, and we'll try to get back to you
-        within a couple of weeks.
+        Although we're currently accepting applications,
+        it may take us a few weeks to reply
+        since we're nearing the end of the academic year.
+        This also means we won't be able to provide new
+        members with full onboarding support at this time.
         <br><br>
         <!--<ul>
         <li class="join-text"><a target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
Resolves #32. Adds this text to the join page:

> Although we're currently accepting applications, it may take us a few weeks to reply since we're nearing the end of the academic year. This also means we won't be able to provide new members with full onboarding support at this time.